### PR TITLE
Pass maxMiniBatchSizeBytes value to the Bulk Executor

### DIFF
--- a/MigrationExecutorApp/ChangeFeedProcessortHost.cs
+++ b/MigrationExecutorApp/ChangeFeedProcessortHost.cs
@@ -173,9 +173,6 @@
 
             var docTransformer = new DefaultDocumentTransformer();
 
-            //BlobServiceClient blobServiceClient = new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=revin;AccountKey=rmN8Esbnyal8q0keILZWx2XdXZpmTHXOVs0lNIigs/nhK25J25zWHWPxDik7LZ2mqIEolJclHPgyEtBOfa4NfA==;EndpointSuffix=core.windows.net");
-            //BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient("cosmosdb-live-etl");
-
             BlobContainerClient containerClient = null;
 
             if (!String.IsNullOrEmpty(config.BlobConnectionString))
@@ -184,10 +181,6 @@
                 containerClient = blobServiceClient.GetBlobContainerClient(config.BlobContainerName);
                 await containerClient.CreateIfNotExistsAsync();
             } 
-            
-
-            //AppendBlobClient appendBlobClient = new AppendBlobClient("DefaultEndpointsProtocol=https;AccountName=revin;AccountKey=rmN8Esbnyal8q0keILZWx2XdXZpmTHXOVs0lNIigs/nhK25J25zWHWPxDik7LZ2mqIEolJclHPgyEtBOfa4NfA==;EndpointSuffix=core.windows.net", "cosmosdb-live-etl", "FailedImportDocs.csv");
-            //appendBlobClient.AppendBlockAsync("hello");
 
             var docObserverFactory = new DocumentFeedObserverFactory(config.SourcePartitionKeys, config.TargetPartitionKey, destClient, destCollInfo, docTransformer, containerClient);
 

--- a/MigrationExecutorApp/DocumentFeedObserverFactory.cs
+++ b/MigrationExecutorApp/DocumentFeedObserverFactory.cs
@@ -11,19 +11,20 @@
         private DocumentClient destClient;
         private readonly string SourcePartitionKeys;
         private readonly string TargetPartitionKey;
-        private MigrationConfig config;
         private DocumentCollectionInfo destCollInfo;
         private IDocumentTransformer documentTransformer;
-        //private AppendBlobClient appendBlobClient;
         private BlobContainerClient containerClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DocumentFeedObserverFactory" /> class.
         /// Saves input DocumentClient and DocumentCollectionInfo parameters to class fields
         /// </summary>
+        /// <param name="SourcePartitionKeys">Attributes from source collection to be mapped as PK in Target</param>
+        /// <param name="TargetPartitionKey">PK attribute name in Target</param>
         /// <param name="destClient">Client connected to destination collection</param>
         /// <param name="destCollInfo">Destination collection information</param>
-        /// /// <param name="docTransformer">Destination collection information</param>
+        /// <param name="docTransformer">Default Document Transformer</param>
+        /// <param name="containerClient">Blob client to persist DLQ docs</param>
         public DocumentFeedObserverFactory(string SourcePartitionKeys, string TargetPartitionKey, DocumentClient destClient, DocumentCollectionInfo destCollInfo, IDocumentTransformer docTransformer, BlobContainerClient containerClient)
         {
             this.destCollInfo = destCollInfo;

--- a/MigrationExecutorApp/MigrationExecutorApp.csproj
+++ b/MigrationExecutorApp/MigrationExecutorApp.csproj
@@ -81,8 +81,9 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=2.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.2.7.2\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.CosmosDB.BulkImport, Version=2.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Azure.CosmosDB.BulkImport, Version=2.5.1.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.CosmosDB.BulkExecutor.1.8.8\lib\net451\Microsoft.Azure.CosmosDB.BulkImport.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.ChangeFeedProcessor, Version=2.2.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.DocumentDB.ChangeFeedProcessor.2.2.8\lib\net45\Microsoft.Azure.Documents.ChangeFeedProcessor.dll</HintPath>

--- a/MigrationWebClient/src/config.js
+++ b/MigrationWebClient/src/config.js
@@ -1,7 +1,7 @@
 var config = {}
 
-config.host = process.env.cosmosdbaccount || "https://migrationdetails-eastus.documents.azure.com:443/";
-config.authKey = process.env.cosmosdbkey || "1mYccQpI3hoLtpBgmzCCLjQOXPnluPSFLxiK5jE3PBJZcrIRH5P47ZlwKmuxiL660k3NVhT5sSAfGtzqqS3lFQ==";
+config.host = process.env.cosmosdbaccount || "";
+config.authKey = process.env.cosmosdbkey || "";
 config.databaseId = process.env.cosmosdbdb || "migrationdetailsdb";
 config.collectionId = process.env.cosmosdbcollection || "migrationdetailscoll";
 config.sourceClient = null;

--- a/MigrationWebClient/src/views/index.jade
+++ b/MigrationWebClient/src/views/index.jade
@@ -17,12 +17,6 @@ html
     if (typeof migration === "undefined")
       form.well(action="/addMigration", method="post")
         .form-group
-          label(for="sourcePartitionKeys") Source Partition Key Attributes (Optional):
-          input.form-control(name="sourcePartitionKeys", type="textbox")
-        .form-group
-          label(for="targetPartitionKey") Target Partition Key Attribute (Optional):
-          input.form-control(name="targetPartitionKey", type="textbox")
-        .form-group
           label(for="monitoredUri") Source Endpoint:
           input.form-control(name="monitoredUri", type="textbox")
         .form-group
@@ -47,6 +41,12 @@ html
           label(for="destCollectionName") Destination Collection:
           input.form-control(name="destCollectionName", type="textbox")
         .form-group
+          label(for="sourcePartitionKeys") Source Partition Key Attributes (Optional):
+          input.form-control(name="sourcePartitionKeys", type="textbox")
+        .form-group
+          label(for="targetPartitionKey") Target Partition Key Attribute (Optional):
+          input.form-control(name="targetPartitionKey", type="textbox")	  
+        .form-group
           label(for="leaseUri") Lease Uri:
           input.form-control(name="leaseUri", type="textbox")
         .form-group
@@ -59,10 +59,10 @@ html
           label(for="leaseCollectionName") Lease Collection Name:
           input.form-control(name="leaseCollectionName", type="textbox")
         .form-group
-          label(for="blobConnectionString") Blob Connection String for Failed/Bad Records tracking (Optional):
+          label(for="blobConnectionString") Blob Connection String for Failed/Bad Records tracking (Optional) :
           input.form-control(name="blobConnectionString", type="textbox")
         .form-group
-          label(for="blobContainerName") Blob Container Name for Failed/Bad Records tracking (Optional):
+          label(for="blobContainerName") Blob Container Name for Failed/Bad Records tracking (Optional) :
           input.form-control(name="blobContainerName", type="textbox")
         .form-group
           label(for="dataAgeInHours") Maximum data age in hours (Optional) :
@@ -76,12 +76,6 @@ html
 
       form(action="/completeMigration", method="post")
         table.table.table-striped.table-bordered
-          tr
-            td Source Partition Key Attributes (Optional)
-            td #{migration.sourcePartitionKeys}
-          tr
-            td Target Partition Key Attribute (Optional)
-            td #{migration.targetPartitionKey}
           tr
             td Source Endpoint
             td #{migration.monitoredUri}


### PR DESCRIPTION
## Purpose
It was observed through several experiments (details in the link below) that reducing maxMiniBatchSize to 100KB and limiting max degree of parallelism to 1 provides up to 50% performance improvement in bulk executor ingestion, in the cases where there are a number of BulkExecutor instances. 

https://microsoft-my.sharepoint.com/:x:/p/rechalil/ETb-wVWvqNRBqXL2VGYi1ncBch-XR2_P5yQ4zJtKjrEuaA?e=SQvmns

## Changes
Exposed the maxMiniBatchSize param in the .net bulk executor and passed the value of 100KB from LDM and cleaned up the repo. 

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
```
