### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 <a name="2.0.0"></a>
 
+
+
+# 2.0.1 (2021-02-11)
+
+*Features*
+
+* Option to create a migration to only insert missing documents. This can be useful if documents have been written to the poison message location initially to reprocess just documents that don't exist in the destination yet.
+
+*Bug Fixes*
+
+* The Monitoring WebApp calculates the number of documents by running a query. Especially for large containers this is less efficient than retrieving the quota info from the Container metadata. So using that approach going forward.
+
+
+
 # 2.0.0 (2020-12-04)
 
 *Features*

--- a/Migration.Executor.WebJob/ItemResponseExtensions.cs
+++ b/Migration.Executor.WebJob/ItemResponseExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Migration.Shared.DataContracts;
@@ -30,7 +31,7 @@ namespace Migration.Executor.WebJob
                     .InnerExceptions
                     .FirstOrDefault(innerEx => innerEx is CosmosException) is CosmosException cosmosException)
                 {
-                    if (ignoreConflicts)
+                    if (ignoreConflicts && cosmosException.StatusCode == HttpStatusCode.Conflict)
                     {
                         return new OperationResponse<T>()
                         {

--- a/Migration.Executor.WebJob/Migration.Executor.WebJob.csproj
+++ b/Migration.Executor.WebJob/Migration.Executor.WebJob.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Migration.Monitor.WebJob/Migration.Monitor.WebJob.csproj
+++ b/Migration.Monitor.WebJob/Migration.Monitor.WebJob.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.3.0" />

--- a/Migration.ResourceGroup/MigrationServices.json
+++ b/Migration.ResourceGroup/MigrationServices.json
@@ -51,7 +51,7 @@
     },
     "migrationAppPackage": {
       "type": "string",
-      "defaultValue": "https://fabianmstorage.blob.core.windows.net/migration-tool/2020-12-07_0001/Migration.UI.WebApp.zip",
+      "defaultValue": "https://fabianmstorage.blob.core.windows.net/migration-tool/2021-02-11_0001/Migration.UI.WebApp.zip",
       "minLength": 3,
       "metadata": {
         "description": "The full path tot he zip-package containing the deployment package for the Migration UI App"
@@ -59,7 +59,7 @@
     },
     "exectuorWebJobPackage": {
       "type": "string",
-      "defaultValue": "https://fabianmstorage.blob.core.windows.net/migration-tool/2020-12-07_0001/Migration.Executor.WebJob.zip",
+      "defaultValue": "https://fabianmstorage.blob.core.windows.net/migration-tool/2021-02-11_0001/Migration.Executor.WebJob.zip",
       "minLength": 3,
       "metadata": {
         "description": "The full path to the zip-package containing the deployment package for the Executor WebJob"
@@ -67,7 +67,7 @@
     },
     "monitorWebJobPackage": {
       "type": "string",
-      "defaultValue": "https://fabianmstorage.blob.core.windows.net/migration-tool/2020-12-07_0001/Migration.Monitor.WebJob.zip",
+      "defaultValue": "https://fabianmstorage.blob.core.windows.net/migration-tool/2021-02-11_0001/Migration.Monitor.WebJob.zip",
       "minLength": 3,
       "metadata": {
         "description": "The full path to the zip-package containing the deployment package for the Monitor WebJob"

--- a/Migration.Shared/DataContracts/MigrationConfig.cs
+++ b/Migration.Shared/DataContracts/MigrationConfig.cs
@@ -36,6 +36,9 @@ namespace Migration.Shared.DataContracts
         [JsonProperty("completed")]
         public bool Completed { get; set; }
 
+        [JsonProperty("onlyInsertMissingItems")]
+        public bool OnlyInsertMissingItems { get; set; }
+
         [JsonProperty("id")]
         public string Id { get; set; }
 

--- a/Migration.UI.WebApp/Migration.UI.WebApp.csproj
+++ b/Migration.UI.WebApp/Migration.UI.WebApp.csproj
@@ -5,7 +5,7 @@
     <UserSecretsId>aspnet-Migration.UI.WebApp-B4E15B89-894D-44F4-8F6E-9F4EB2765B5E</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
     <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Migration.UI.WebApp/Pages/NewMigration.cshtml
+++ b/Migration.UI.WebApp/Pages/NewMigration.cshtml
@@ -19,7 +19,7 @@
         <tbody>
             <tr>
                 <td><b>Id:</b></td>
-                <td colspan="2"><input type="text" id="txtId" name="id" value="@Guid.NewGuid().ToString("N")" readonly="readonly" style="min-width: 100%"  /></td>
+                <td colspan="2"><input type="text" id="txtId" name="id" value="@Guid.NewGuid().ToString("N")" readonly="readonly" style="min-width: 100%" /></td>
             </tr>
             <tr>
                 <td><b>Account:</b></td>
@@ -40,6 +40,10 @@
                 <td><b>PK:</b></td>
                 <td><input type="text" id="txtSourcePK" name="sourcePK" style="min-width: 400px" /></td>
                 <td><input type="text" id="txtDestinationPK" name="destinationPK" style="min-width: 400px" /></td>
+            </tr>
+            <tr>
+                <td colspan="2"><b>Only missing docuemnts?</b></td>
+                <td><input type="checkbox" id="chkOnlyMissingDocuments" name="onlyMissingDocuments" /></td>
             </tr>
         </tbody>
     </table>

--- a/Migration.UI.WebApp/Pages/NewMigration.cshtml
+++ b/Migration.UI.WebApp/Pages/NewMigration.cshtml
@@ -42,7 +42,7 @@
                 <td><input type="text" id="txtDestinationPK" name="destinationPK" style="min-width: 400px" /></td>
             </tr>
             <tr>
-                <td colspan="2"><b>Only missing docuemnts?</b></td>
+                <td colspan="2"><b>Only missing documents?</b></td>
                 <td><input type="checkbox" id="chkOnlyMissingDocuments" name="onlyMissingDocuments" /></td>
             </tr>
         </tbody>

--- a/Migration.UI.WebApp/Pages/NewMigration.cshtml.cs
+++ b/Migration.UI.WebApp/Pages/NewMigration.cshtml.cs
@@ -17,7 +17,8 @@ namespace Migration.UI.WebApp.Pages
             string destinationAccount,
             string destinationDatabase,
             string destinationContainer,
-            string destinationPK)
+            string destinationPK,
+            bool onlyMissingDocuments)
         {
             MigrationConfig newConfig = new MigrationConfig
             {
@@ -31,7 +32,8 @@ namespace Migration.UI.WebApp.Pages
                 DestCollectionName = destinationContainer,
                 TargetPartitionKey = destinationPK,
                 Completed = false,
-                StartTimeEpochMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                StartTimeEpochMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                OnlyInsertMissingItems = onlyMissingDocuments,
             };
 
             await MigrationConfigDal.Singleton

--- a/Migration.UI.WebApp/Pages/NewMigration.cshtml.cs
+++ b/Migration.UI.WebApp/Pages/NewMigration.cshtml.cs
@@ -22,7 +22,7 @@ namespace Migration.UI.WebApp.Pages
         {
             MigrationConfig newConfig = new MigrationConfig
             {
-                Id = id,
+                Id = id != null && id.StartsWith("/") ? id[1..] : id,
                 MonitoredAccount = sourceAccount,
                 MonitoredDbName = sourceDatabase,
                 MonitoredCollectionName = sourceContainer,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Azure Cosmos DB Live Data Migrator
 Simple and reliable service to transfer data from one Cosmos DB SQL API container to another in a live fashion.
 
+
+
+## IMPORTANT
+
+The purpose of this tool is to allow starting the migration of data significantly ahead of the actual cut-over date. Every migration started will use the change feed of the source container to listen on updates to be migrated to the destination. It is strongly advised to migrate the bulk of items using this mechanism at least several days before the cut-over-date to reduce the risk of unnecessary fire-drills due to unexpected delays or issues identified during migration. 
+
+
+
 ## Features
 
 The Cosmos DB Live Data Migrator provides the following features:


### PR DESCRIPTION
# 2.0.1 (2021-02-11)

*Features*

* Option to create a migration to only insert missing documents. This can be useful if documents have been written to the poison message location initially to reprocess just documents that don't exist in the destination yet.

*Bug Fixes*

* The Monitoring WebApp calculates the number of documents by running a query. Especially for large containers this is less efficient than retrieving the quota info from the Container metadata. So using that approach going forward.


