### PR TITLE
Make setters public to allow serializer to interpret document state

### DIFF
--- a/Migration.Shared/DataContracts/Resource.cs
+++ b/Migration.Shared/DataContracts/Resource.cs
@@ -92,7 +92,7 @@ namespace Migration.Shared.DataContracts
         public string SelfLink
         {
             get => this.GetValue<string>("_self");
-            internal set => this.SetValue("_self", value);
+            set => this.SetValue("_self", value);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace Migration.Shared.DataContracts
             get =>
                 // Add seconds to the unix start time
                 UnixStartTime.AddSeconds(this.GetValue<double>("_ts"));
-            internal set => this.SetValue("_ts", (ulong)(value - UnixStartTime).TotalSeconds);
+            set => this.SetValue("_ts", (ulong)(value - UnixStartTime).TotalSeconds);
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace Migration.Shared.DataContracts
         public string ETag
         {
             get => this.GetValue<string>("_etag");
-            internal set => this.SetValue("_etag", value);
+            set => this.SetValue("_etag", value);
         }
 
         /// <summary>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixed a serialization bug that prevented documents from being read from Cosmos DB

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Try run a migration from a populated SourceContainer to an empty TargetContainer. The migration tool should move all the documents from SourceContainer to TargetContainer.

## What to Check
* Verify that the count of the TargetContainer is equal to the SourceContainer after the migration.
